### PR TITLE
chore: cross-platform config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,25 @@ env:
   PNPM_VERSION: '8'
 
 jobs:
+  workspace:
+    name: Workspace Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
+      - run: pnpm -v && node -v
+      - run: pnpm -w install
+      - run: pnpm run check:engines
+      - run: pnpm -w build
   # Job 1: Build and test all packages
   test:
     name: Build and Test

--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,3 @@
 enable-pre-post-scripts=true
 strict-peer-dependencies=false
 auto-install-peers=true
-supportedArchitectures.os=["win32"]
-supportedArchitectures.cpu=["x64"]
-supportedArchitectures.libc=[]

--- a/README.md
+++ b/README.md
@@ -555,16 +555,18 @@ flowlock-open/
 
 ## 🛠️ Development
 
+Ensure you have **Node.js >= 18** and **pnpm >= 8** installed.
+
 ```bash
 # Clone repository
 git clone https://github.com/yourusername/flowlock-open.git
 cd flowlock-open
 
 # Install dependencies
-pnpm install
+pnpm -w install
 
 # Build all packages
-pnpm build
+pnpm -w build
 
 # Run tests
 pnpm test

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -1,0 +1,20 @@
+# Development Notes
+
+This project uses a pnpm workspace and is designed to work across macOS, Linux, and Windows.
+
+## Requirements
+
+- Node.js >= 18
+- pnpm >= 8
+
+## Common Commands
+
+Run commands from the repository root with the workspace flag:
+
+```bash
+pnpm -w install
+pnpm -w build
+```
+
+These commands resolve packages consistently on all supported platforms.
+

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "flowlock",
   "version": "0.2.0",
   "private": true,
+  "workspaces": ["packages/*"],
   "description": "UX specification validation and code generation framework",
   "scripts": {
     "prebuild": "pnpm build:deps",
@@ -19,7 +20,8 @@
     "uxcg:diagrams": "uxcg diagrams",
     "uxcg:watch": "uxcg watch",
     "flowlock": "node ./packages/cli-tui/dist/bin/flowlock.js",
-    "tui": "node ./packages/cli-tui/dist/bin/flowlock.js"
+    "tui": "node ./packages/cli-tui/dist/bin/flowlock.js",
+    "check:engines": "node ./scripts/check-engines.mjs"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",
@@ -27,7 +29,8 @@
     "eslint": "^8.54.0",
     "prettier": "^3.1.0",
     "typescript": "^5.3.2",
-    "vitest": "^1.0.0"
+    "vitest": "^1.0.0",
+    "semver": "^7.5.4"
   },
   "engines": {
     "node": ">=18.0.0",

--- a/packages/checks-core/package.json
+++ b/packages/checks-core/package.json
@@ -20,8 +20,15 @@
     "validation",
     "flowlock"
   ],
+  "type": "commonjs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "build": "tsup",
     "test": "vitest run",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,8 +21,15 @@
     "cli",
     "flowlock"
   ],
+  "type": "commonjs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "bin": {
     "uxcg": "dist/index.js"
   },

--- a/packages/inventory/package.json
+++ b/packages/inventory/package.json
@@ -4,8 +4,15 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,9 +1,12 @@
 {
   "name": "flowlock-mcp",
   "version": "0.10.0",
+  "type": "commonjs",
+  "main": "dist/server.js",
   "bin": {
     "flowlock-mcp": "dist/server.js"
   },
+  "exports": "./dist/server.js",
   "scripts": {
     "build": "tsup",
     "dev": "tsx src/server.ts",

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -20,8 +20,15 @@
     "sdk",
     "flowlock"
   ],
+  "type": "commonjs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "build": "tsup",
     "test": "vitest run",

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -20,8 +20,15 @@
     "test",
     "flowlock"
   ],
+  "type": "commonjs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "build": "tsup",
     "test": "vitest run",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,6 +2,7 @@
   "name": "flowlock-shared",
   "version": "0.10.0",
   "description": "Shared utilities and types for FlowLock system",
+  "type": "commonjs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/uxspec/package.json
+++ b/packages/uxspec/package.json
@@ -20,8 +20,15 @@
     "specification",
     "flowlock"
   ],
+  "type": "commonjs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "build": "tsup",
     "test": "vitest run",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       prettier:
         specifier: ^3.1.0
         version: 3.6.2
+      semver:
+        specifier: ^7.5.4
+        version: 7.7.2
       typescript:
         specifier: ^5.3.2
         version: 5.9.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 packages:
   - 'packages/*'
-  - 'packages/mcp'
   - 'apps/*'
   - 'action/*'
-  - "example"
+  - 'example'
+

--- a/scripts/check-engines.mjs
+++ b/scripts/check-engines.mjs
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { satisfies } from 'semver';
+
+const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url)));
+
+const nodeVersion = process.versions.node;
+const pnpmVersion = execSync('pnpm -v').toString().trim();
+
+let ok = true;
+if (!satisfies(nodeVersion, pkg.engines.node)) {
+  console.error(`Node.js ${nodeVersion} does not satisfy required range ${pkg.engines.node}`);
+  ok = false;
+}
+if (!satisfies(pnpmVersion, pkg.engines.pnpm)) {
+  console.error(`pnpm ${pnpmVersion} does not satisfy required range ${pkg.engines.pnpm}`);
+  ok = false;
+}
+if (!ok) {
+  process.exit(1);
+} else {
+  console.log(`Node.js ${nodeVersion} and pnpm ${pnpmVersion} satisfy engines`);
+}
+


### PR DESCRIPTION
## Summary
- remove Windows-specific npm config entries
- declare workspaces and engine check script
- add cross-platform workspace build job

## Testing
- `pnpm -w install`
- `pnpm -w build`
- `pnpm run check:engines`


------
https://chatgpt.com/codex/tasks/task_e_68aa078d0a10832b935e66c442052c4d