### PR TITLE
feat: strict config validation for paths and URLs

### DIFF
--- a/packages/shared/src/config-validator.ts
+++ b/packages/shared/src/config-validator.ts
@@ -4,7 +4,7 @@
 
 import { FlowlockConfig } from './types';
 import { ConfigurationError } from './errors';
-import { validateRequiredField, validateArrayField, validateEnum } from './validation';
+import { validateRequiredField, validateArrayField, validateEnum, validatePath, validateUrl } from './validation';
 
 const VALID_DB_MODES = ['auto', 'schema', 'live'] as const;
 const VALID_DB_DIALECTS = ['postgres', 'mysql', 'sqlite'] as const;
@@ -42,6 +42,9 @@ export function validateFlowlockConfig(config: any): FlowlockConfig {
       }
       if (inv.db.schemaFiles) {
         validateArrayField(inv.db.schemaFiles, 'inventory.db.schemaFiles');
+        inv.db.schemaFiles = inv.db.schemaFiles.map((p: string) =>
+          validatePath(p, 'inventory.db.schemaFiles')
+        );
       }
     }
 
@@ -49,6 +52,12 @@ export function validateFlowlockConfig(config: any): FlowlockConfig {
     if (inv.api) {
       if (inv.api.scan) {
         validateArrayField(inv.api.scan, 'inventory.api.scan');
+        inv.api.scan = inv.api.scan.map((p: string) =>
+          validatePath(p, 'inventory.api.scan')
+        );
+      }
+      if (inv.api.specUrl) {
+        inv.api.specUrl = validateUrl(inv.api.specUrl, 'inventory.api.specUrl');
       }
     }
 
@@ -56,6 +65,9 @@ export function validateFlowlockConfig(config: any): FlowlockConfig {
     if (inv.ui) {
       if (inv.ui.scan) {
         validateArrayField(inv.ui.scan, 'inventory.ui.scan');
+        inv.ui.scan = inv.ui.scan.map((p: string) =>
+          validatePath(p, 'inventory.ui.scan')
+        );
       }
     }
   }

--- a/packages/shared/src/errors.ts
+++ b/packages/shared/src/errors.ts
@@ -6,6 +6,8 @@ export interface ErrorDetails {
   expected?: any;
   actual?: any;
   location?: string;
+  field?: string;
+  reason?: string;
   suggestion?: string;
   documentation?: string;
   context?: Record<string, any>;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -16,6 +16,7 @@ export interface FlowlockConfig {
       scan?: string[];
       jsdoc?: boolean;
       openapiPrefer?: boolean;
+      specUrl?: string;
     };
     ui?: {
       scan?: string[];

--- a/packages/shared/src/validation.ts
+++ b/packages/shared/src/validation.ts
@@ -2,47 +2,105 @@
  * Shared validation utilities for FlowLock system
  */
 
-import { ValidationError } from './errors';
+import path from 'node:path';
+import { ValidationError, ErrorCodes } from './errors';
 
 export function validateRequiredField(value: any, fieldName: string): void {
   if (value === null || value === undefined || value === '') {
-    throw new ValidationError(`Required field '${fieldName}' is missing`);
+    throw new ValidationError(
+      `Required field '${fieldName}' is missing`,
+      ErrorCodes.CONFIG_MISSING_REQUIRED,
+      {
+        field: fieldName,
+        reason: 'missing',
+        suggestion: `Add '${fieldName}' to configuration`
+      }
+    );
   }
 }
 
 export function validateArrayField(value: any, fieldName: string): void {
   if (!Array.isArray(value)) {
-    throw new ValidationError(`Field '${fieldName}' must be an array`);
+    throw new ValidationError(
+      `Field '${fieldName}' must be an array`,
+      ErrorCodes.CONFIG_INVALID_VALUE,
+      {
+        field: fieldName,
+        reason: 'type',
+        suggestion: `Use an array for '${fieldName}'`
+      }
+    );
   }
 }
 
 export function validateObjectField(value: any, fieldName: string): void {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    throw new ValidationError(`Field '${fieldName}' must be an object`);
+    throw new ValidationError(
+      `Field '${fieldName}' must be an object`,
+      ErrorCodes.CONFIG_INVALID_VALUE,
+      {
+        field: fieldName,
+        reason: 'type',
+        suggestion: `Use an object for '${fieldName}'`
+      }
+    );
   }
 }
 
 export function validateEnum<T>(value: T, validValues: readonly T[], fieldName: string): void {
   if (!validValues.includes(value)) {
     throw new ValidationError(
-      `Invalid value for '${fieldName}': ${value}. Must be one of: ${validValues.join(', ')}`
+      `Invalid value for '${fieldName}': ${value}. Must be one of: ${validValues.join(', ')}`,
+      ErrorCodes.CONFIG_INVALID_VALUE,
+      {
+        field: fieldName,
+        reason: 'enum',
+        suggestion: `Use one of: ${validValues.join(', ')}`
+      }
     );
   }
 }
 
-export function validatePath(path: string, fieldName: string): void {
-  if (!path || typeof path !== 'string') {
-    throw new ValidationError(`Field '${fieldName}' must be a non-empty string path`);
+export function validatePath(p: string, fieldName: string): string {
+  if (!p || typeof p !== 'string') {
+    throw new ValidationError(
+      `Field '${fieldName}' must be a non-empty string path`,
+      ErrorCodes.CONFIG_INVALID_VALUE,
+      {
+        field: fieldName,
+        reason: 'empty',
+        suggestion: `Provide a valid path for ${fieldName}`
+      }
+    );
   }
-  if (path.includes('..')) {
-    throw new ValidationError(`Field '${fieldName}' contains invalid path traversal`);
+  const segments = p.split(/\\|\//);
+  if (segments.includes('..')) {
+    throw new ValidationError(
+      `Field '${fieldName}' contains invalid path traversal`,
+      ErrorCodes.CONFIG_INVALID_VALUE,
+      {
+        field: fieldName,
+        reason: 'path-traversal',
+        suggestion: `Remove ../ from ${fieldName}`
+      }
+    );
   }
+  return path.resolve(path.normalize(p));
 }
 
-export function validateUrl(url: string, fieldName: string): void {
+export function validateUrl(u: string, fieldName: string): string {
   try {
-    new URL(url);
+    const parsed = new URL(u);
+    return parsed.toString();
   } catch {
-    throw new ValidationError(`Field '${fieldName}' must be a valid URL`);
+    throw new ValidationError(
+      `Field '${fieldName}' must be a valid URL`,
+      ErrorCodes.CONFIG_INVALID_VALUE,
+      {
+        field: fieldName,
+        reason: 'invalid-url',
+        suggestion: `Provide a valid URL for ${fieldName}`
+      }
+    );
   }
 }

--- a/packages/shared/tests/config-validator.test.ts
+++ b/packages/shared/tests/config-validator.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { validateFlowlockConfig } from '../src/config-validator';
+import { ValidationError } from '../src/errors';
+
+describe('config validator path/url validation', () => {
+  it('canonicalizes schemaFiles and specUrl', () => {
+    const cfg = {
+      projectName: 'demo',
+      inventory: {
+        db: { schemaFiles: ['./schemas/schema.prisma'] },
+        api: { specUrl: 'http://example.com/spec.yaml' }
+      }
+    };
+
+    const validated = validateFlowlockConfig(cfg);
+    expect(validated.inventory!.db!.schemaFiles![0]).toBe(
+      path.resolve('./schemas/schema.prisma')
+    );
+    expect(validated.inventory!.api!.specUrl).toBe('http://example.com/spec.yaml');
+  });
+
+  it('rejects path traversal', () => {
+    const cfg = {
+      projectName: 'demo',
+      inventory: { db: { schemaFiles: ['../secret.sql'] } }
+    };
+    try {
+      validateFlowlockConfig(cfg);
+      throw new Error('should have thrown');
+    } catch (err) {
+      const v = err as ValidationError;
+      expect(v.details).toMatchInlineSnapshot(`
+        {
+          "field": "inventory.db.schemaFiles",
+          "reason": "path-traversal",
+          "suggestion": "Remove ../ from inventory.db.schemaFiles",
+        }
+      `);
+    }
+  });
+
+  it('rejects malformed URLs', () => {
+    const cfg = {
+      projectName: 'demo',
+      inventory: { api: { specUrl: 'ht!tp://bad url' } }
+    };
+    try {
+      validateFlowlockConfig(cfg);
+      throw new Error('should have thrown');
+    } catch (err) {
+      const v = err as ValidationError;
+      expect(v.details).toMatchInlineSnapshot(`
+        {
+          "field": "inventory.api.specUrl",
+          "reason": "invalid-url",
+          "suggestion": "Provide a valid URL for inventory.api.specUrl",
+        }
+      `);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- strengthen validation utilities with canonical path and URL checks
- apply strict path and URL validation in config validator and types
- add tests covering canonicalization, path traversal, and malformed URLs

## Testing
- `npx vitest packages/shared/tests/config-validator.test.ts --run`


------
https://chatgpt.com/codex/tasks/task_e_68aa0ba24a34832b88048a676a27d5b0